### PR TITLE
send 500 HTTP status code in case of database error

### DIFF
--- a/common.php
+++ b/common.php
@@ -142,6 +142,7 @@ if(!phorum_db_check_connection()){
         phorum_redirect_by_url($PHORUM["DBCONFIG"]["down_page"]);
         exit();
     } else {
+        header('HTTP/1.1 500 Internal Server Error');
         echo "The database connection failed. Please check your database configuration in include/db/config.php. If the configuration is okay, check if the database server is running.";
         exit();
     }


### PR DESCRIPTION
this allows you to track from accesslogs failed requests, and in case of
some frontend server, act accordingly if the status code is not correct

also makes search engines not to index your error pages!
