### PR TITLE
added a missing AND to SQL

### DIFF
--- a/include/db/PhorumDB.php
+++ b/include/db/PhorumDB.php
@@ -3382,7 +3382,7 @@ abstract class PhorumDB
              FROM   {$this->user_permissions_table} AS perm
                     INNER JOIN {$this->user_table} AS u
                     ON perm.user_id = u.user_id
-             WHERE  perm.forum_id = $forum_id AND u.active = 1
+             WHERE  perm.forum_id = $forum_id AND u.active = 1 AND
                     perm.permission>=".PHORUM_USER_ALLOW_MODERATE_MESSAGES." AND
                     (perm.permission & ".PHORUM_USER_ALLOW_MODERATE_MESSAGES.">0)
                     $where_moderation_mail"


### PR DESCRIPTION
would error with 'You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'perm.permission>=64 AND (perm.permission & 64>0)' at line 7 (1064):'
