### PR TITLE
Master revert some changes from issue 598

### DIFF
--- a/include/api/mail/message_moderate.php
+++ b/include/api/mail/message_moderate.php
@@ -40,7 +40,7 @@ function phorum_api_mail_message_moderate($message)
 {
     // Not "global $PHORUM", because we do not want the loading of language
     // files to override our already loaded language file.
-    global $PHORUM;
+    $PHORUM = $GLOBALS['PHORUM'];
 
     // Retrieve the list of moderators for the current forum.
     $moderators = phorum_api_user_list_moderators(

--- a/include/api/mail/message_notify.php
+++ b/include/api/mail/message_notify.php
@@ -39,7 +39,7 @@ function phorum_api_mail_message_notify($message)
 {
     // Not "global $PHORUM", because we do not want the loading of language
     // files to override our already loaded language file.
-    global $PHORUM;
+    $PHORUM = $GLOBALS['PHORUM'];
 
     // Check if email notifications are allowed for the current forum.
     if (empty($PHORUM['allow_email_notify'])) return;

--- a/include/api/mail/pm_notify.php
+++ b/include/api/mail/pm_notify.php
@@ -42,7 +42,7 @@ function phorum_api_mail_pm_notify($message, $recipients)
 {
     // Not "global $PHORUM", because we do not want the loading of language
     // files to override our already loaded language file.
-    global $PHORUM;
+    $PHORUM = $GLOBALS['PHORUM'];
 
     // Sort all recipients that want a notification by their preferred language.
     $recipients_by_lang = array();


### PR DESCRIPTION
Not "global $PHORUM", because we do not want the loading of language files to override our already loaded language file.