### PR TITLE
New settings for stripping message bodies

### DIFF
--- a/common.php
+++ b/common.php
@@ -26,13 +26,13 @@ if ( basename( __FILE__ ) == basename( $_SERVER["PHP_SELF"] ) ) exit();
 // ----------------------------------------------------------------------
 
 // the Phorum version
-define( "PHORUM", "5.2.20" );
+define( "PHORUM", "5.2.21" );
 
 // our database schema version in format of year-month-day-serial
 define( "PHORUM_SCHEMA_VERSION", "2010101500" );
 
 // our database patch level in format of year-month-day-serial
-define( "PHORUM_SCHEMA_PATCHLEVEL", "2012030800" );
+define( "PHORUM_SCHEMA_PATCHLEVEL", "2015082600" );
 
 // Initialize the global $PHORUM variable, which holds all Phorum data.
 global $PHORUM;

--- a/include/admin/install.php
+++ b/include/admin/install.php
@@ -117,7 +117,7 @@ if ($step == 'start' && !isset($_POST["sanity_checks_done"]))
         <br/>
         One or more critical errors were encountered while checking
         your system. To see what is causing these errors and what you
-        can do about them, click the "show problem info" links.
+        can do about them, click the &quot;show problem info&quot; links.
         Please fix these errors and restart the system checks.
         <br/><br/>
         <input type="submit" value="Restart the system checks" />
@@ -128,9 +128,9 @@ if ($step == 'start' && !isset($_POST["sanity_checks_done"]))
         <br/>
         One or more warnings were encountered while checking
         your system. To see what is causing these warnings and what you
-        can do about them, click the "show problem info" links.
+        can do about them, click the &quot;show problem info&quot; links.
         Phorum probably will run without fixing the warnings, but
-        it's a good idea to fix them anyway for ensuring optimal
+        it&apos;s a good idea to fix them anyway for ensuring optimal
         performance.
         <br/><br/>
         <input type="submit" value="Restart the system checks" />
@@ -276,9 +276,6 @@ switch ($step){
 
             // insert the default module settings
             // hooks
-
-
-
             $mods_initial = array (
                 'announcements' => 1,
                 'bbcode' => 1,
@@ -378,6 +375,8 @@ switch ($step){
             "cache_messages" => 0,
             "redirect_after_post" => "list",
             "reply_on_read_page" => 1,
+            "strip_quote_posting_form" => 0,
+            "strip_quote_mail" => 0,
             "status" => "normal",
             "use_new_folder_style" => 1,
             "default_forum_options" => $default_forum_options,
@@ -519,7 +518,7 @@ switch ($step){
 
         $cont_url = phorum_admin_build_url('');
         phorum_db_update_settings( array("installed"=>1) );
-        echo "The setup is complete.  You can now go to <a href=\"$cont_url\">the admin</a> and start making Phorum all your own.<br /><br /><strong>Here are some things you will want to look at:</strong><br /><br /><a href=\"$_SERVER[PHP_SELF]?module=settings\">The General Settings page</a><br /><br /><a href=\"$_SERVER[PHP_SELF]?module=mods\">Pre-installed modules</a><br /><br /><a href=\"docs/faq.txt\">The FAQ</a><br /><br /><a href=\"docs/performance.txt\">How to get peak performance from Phorum</a><br /><br /><strong>For developers:</strong><br /><br /><a href=\"docs/creating_mods.txt\">Module Creation</a><br /><br /><a href=\"docs/permissions.txt\">How Phorum permisssions work</a><br /><br /><a href=\"docs/CODING-STANDARDS\">The Phorum Team's codings standards</a>";
+        echo "The setup is complete.  You can now go to <a href=\"$cont_url\">the admin</a> and start making Phorum all your own.<br /><br /><strong>Here are some things you will want to look at:</strong><br /><br /><a href=\"$_SERVER[PHP_SELF]?module=settings\">The General Settings page</a><br /><br /><a href=\"$_SERVER[PHP_SELF]?module=mods\">Pre-installed modules</a><br /><br /><a href=\"docs/faq.txt\">The FAQ</a><br /><br /><a href=\"docs/performance.txt\">How to get peak performance from Phorum</a><br /><br /><strong>For developers:</strong><br /><br /><a href=\"docs/creating_mods.txt\">Module Creation</a><br /><br /><a href=\"docs/permissions.txt\">How Phorum permisssions work</a><br /><br /><a href=\"docs/CODING-STANDARDS\">The Phorum Team&apos;s codings standards</a>";
 
         break;
 
@@ -550,7 +549,7 @@ switch ($step){
         error_reporting(E_WARN);
         if ($message == "") {
             if($err){
-                $message.="Your cache directory is not writable. Please change the permissions on '/cache' inside the Phorum directory to allow writing. In Unix, you may have to use this command: chmod 777 cache<br /><br />If you want to continue anyway and set a cache directory manually, press continue. Note that you must do this, Phorum will not work without a valid cache.";
+                $message.="Your cache directory is not writable. Please change the permissions on &apos;/cache&apos; inside the Phorum directory to allow writing. In Unix, you may have to use this command: chmod 777 cache<br /><br />If you want to continue anyway and set a cache directory manually, press continue. Note that you must do this, Phorum will not work without a valid cache.";
             } else {
                 $message.="Cache directory set.  Next we will create a user with administrator privileges.  Press continue when ready.";
             }

--- a/include/admin/settings.php
+++ b/include/admin/settings.php
@@ -237,6 +237,8 @@ $row=$frm->addrow( "After posting go to", $frm->select_tag( "redirect_after_post
 $row=$frm->addrow( "After submitting a search query", $frm->select_tag( "skip_intermediate_search_page", array( 0=>"show an intermediate page (\"search is running\")", 1=>"directly go to the search results" ), $PHORUM["skip_intermediate_search_page"] ) );
 $frm->addhelp($row, "After search action", "On large forums or slow servers, searching for messages might take a little while. To prevent users from submitting the same search query over and over again (in case they think the search didn't work, because they didn't get their results fast enough), you can show an intermediate page, telling the user that the search is running. If your system can deliver search results quickly enough, then you can skip the intermediate page and go directly to the search results page.");
 
+$row=$frm->addrow( "How to strip a quote on the posting form", $frm->select_tag( "strip_quote_posting_form", array( 0=>"Strip HTML and BBCode <tags>", 1=>"Strip HTML <tags>" ), $PHORUM["strip_quote_posting_form"] ) );
+
 $row=$frm->addrow( "Database error handling", $frm->select_tag( "error_logging", array( "screen"=>"Errors will be shown on the screen", "file"=>"Errors will go to a logfile (".$PHORUM['cache']."/phorum-sql-errors.log)", "mail"=> "Errors will be emailed to the system email address"), $PHORUM["error_logging"] ) );
 
 $row=$frm->addrow( "Secret private key for signing data", $frm->text_box("private_key", $PHORUM["private_key"], 50) );
@@ -403,6 +405,8 @@ $row=$frm->addrow( "System Emails From Name", $frm->text_box( "system_email_from
 $row=$frm->addrow( "System Emails From Address", $frm->text_box( "system_email_from_address", $PHORUM["system_email_from_address"], 30 ) );
 
 $row=$frm->addrow( "Use BCC in sending mails:", $frm->select_tag( "use_bcc", array( "No", "Yes" ), $PHORUM["use_bcc"] ) );
+
+$row=$frm->addrow( "How to strip quotes in mails", $frm->select_tag( "strip_quote_mail", array( 0=>"Strip HTML and BBCode <tags>", 1=>"Strip HTML <tags>" ), $PHORUM["strip_quote_mail"] ) );
 
 $row=$frm->addrow( "Ignore Admin for moderator-emails:", $frm->select_tag( "email_ignore_admin", array( "No", "Yes" ), $PHORUM["email_ignore_admin"] ) );
 $frm->addhelp($row, "Ignore Admin for moderator-emails", "If you select yes for this option, then the moderator-notifications and report-message emails will not be sent to the admininistrator, only to moderators" );

--- a/include/db/upgrade/mysql-patches/2015082600.php
+++ b/include/db/upgrade/mysql-patches/2015082600.php
@@ -1,0 +1,21 @@
+<?php
+
+// Initialize some default setting values.
+
+if (!defined('PHORUM_ADMIN')) return;
+
+$update_settings = array();
+
+if (!isset($PHORUM['strip_quote_posting_form'])) {
+    $update_settings['strip_quote_posting_form'] = 0;
+}
+
+if (!isset($PHORUM['strip_quote_mail'])) {
+    $update_settings['strip_quote_mail'] = 0;
+}
+
+if (!empty($update_settings)) {
+    phorum_db_update_settings($update_settings);
+}
+
+?>

--- a/include/email_functions.php
+++ b/include/email_functions.php
@@ -286,7 +286,7 @@ function phorum_email_pm_notice($message, $langusers)
         "author"         => phorum_api_user_get_display_name($message["user_id"], $message["from_username"], PHORUM_FLAG_PLAINTEXT),
         "subject"        => $message["subject"],
         "full_body"      => $message["message"],
-        "plain_body"     => wordwrap(phorum_strip_body($message["message"]),72),
+        "plain_body"     => wordwrap(phorum_strip_body($message["message"], true, $PHORUM["strip_quote_mail"]),72),
         "read_url"       => phorum_get_url_no_uri_auth(PHORUM_PM_URL, "page=read", "pm_id=" . $message["pm_message_id"]),
 
         // For email_user_start.
@@ -346,7 +346,7 @@ function phorum_email_notice($message)
             "author"      => phorum_api_user_get_display_name($message["user_id"], $message["author"], PHORUM_FLAG_PLAINTEXT),
             "subject"     => $message['subject'],
             "full_body"   => $message['body'],
-            "plain_body"  => phorum_strip_body($message['body']),
+            "plain_body"  => phorum_strip_body($message['body'], true, $PHORUM["strip_quote_mail"]),
             "read_url"    => phorum_get_url_no_uri_auth(PHORUM_READ_URL, $message['thread'], $message['message_id']),
             "remove_url"  => phorum_get_url_no_uri_auth(PHORUM_FOLLOW_URL, $message['thread'], "stop=1"),
             "noemail_url" => phorum_get_url_no_uri_auth(PHORUM_FOLLOW_URL, $message['thread'], "noemail=1"),
@@ -406,7 +406,7 @@ function phorum_email_moderators($message)
             "author"      => phorum_api_user_get_display_name($message["user_id"], $message["author"], PHORUM_FLAG_PLAINTEXT),
             "subject"     => $message['subject'],
             "full_body"   => $message['body'],
-            "plain_body"  => phorum_strip_body($message['body']),
+            "plain_body"  => phorum_strip_body($message['body'], true, $PHORUM["strip_quote_mail"]),
             "approve_url" => phorum_get_url_no_uri_auth(PHORUM_CONTROLCENTER_URL, "panel=messages"),
             "read_url"    => phorum_get_url_no_uri_auth(PHORUM_READ_URL, $message['thread'], $message['message_id']),
             "mailmessage" => $mailmessage,

--- a/include/format_functions.php
+++ b/include/format_functions.php
@@ -256,7 +256,7 @@ function phorum_date( $picture, $ts )
 /**
  * Formats an epoch timestamp to a relative time phrase
  *
- * @param ts - The epoch timestamp to format
+ * @param time - The epoch timestamp to format
  * @return phrase - The formatted phrase
  */
 function phorum_relative_date($time)
@@ -308,18 +308,22 @@ function phorum_relative_date($time)
 }
 
 /**
- * Strips HTML <tags> and BBcode [tags] from the body.
+ * Strips HTML <tags> and BBcode [tags] and replaces bad-words from the body.
  *
  * @param body - The block of body text to strip
+ * @param strip_tags - Should tags be stripped?
+ * @param which_tags - Which tags should be stripped? 0=HTML and BBCode, 1=HTML
  * @return stripped - The stripped body
  */
-function phorum_strip_body( $body, $strip_tags = true)
+function phorum_strip_body( $body, $strip_tags = true, $which_tags = 0 )
 {
     if($strip_tags) {
         // Strip HTML <tags>
         $stripped = preg_replace("|</*[a-z][^>]*>|i", "", $body);
-        // Strip BB Code [tags]
-        $stripped = preg_replace("|\[/*[a-z][^\]]*\]|i", "", $stripped);
+        if(empty($which_tags)) {
+          // Strip BB Code [tags]
+          $stripped = preg_replace("|\[/*[a-z][^\]]*\]|i", "", $stripped);
+        }
     } else {
         $stripped = $body;
     }
@@ -363,7 +367,7 @@ function phorum_strip_body( $body, $strip_tags = true)
  * readable formats are MB (MegaByte), KB (KiloByte) and byte.
  *
  * @param bytes - The number of bytes
- * @param formatted - The formatted size
+ * @return formatted - The formatted size
  */
 function phorum_filesize( $bytes )
 {

--- a/mods/bbcode/Changelog
+++ b/mods/bbcode/Changelog
@@ -1,6 +1,12 @@
 Changelog:
 ----------
 
+2015-08-28 v2.0.12
+
+   - Stripping message body (optional stripping HTML and BBCode <tags>,
+     replacing bad words) using corresponding core function when quoting
+     a message.
+
 2010-11-06 v2.0.11
 
    - added option to add the nofollow attribute only to external URLs

--- a/mods/bbcode/README
+++ b/mods/bbcode/README
@@ -1,5 +1,5 @@
 Module  : BBcode
-Version : 2.0.11
+Version : 2.0.12
 Author  : Phorum Dev Team
 
 This module allows users to add BBcode (Bulletin Board Code) tags to their

--- a/mods/bbcode/bbcode.php
+++ b/mods/bbcode/bbcode.php
@@ -113,6 +113,7 @@ function phorum_mod_bbcode_format($data)
 // Quote hook, for overriding the default Phorum message quoting method.
 function phorum_mod_bbcode_quote ($data)
 {
+    global $PHORUM;
     // Some other hook already formatted the quote.
     if (!is_array($data)) return $data;
 
@@ -130,7 +131,7 @@ function phorum_mod_bbcode_quote ($data)
             $author = '"' . $author . '"';
         }
 
-        return "[quote=$author]\n$data[1][/quote]";
+        return "[quote=$author]\n".phorum_strip_body($data[1], true, $PHORUM["strip_quote_posting_form"]).'[/quote]';
     }
     else  {
         return $data;

--- a/mods/bbcode/info.txt
+++ b/mods/bbcode/info.txt
@@ -1,6 +1,6 @@
 title: BBcode
 desc:  This module allows users to add BBcode (Bulletin Board Code) tags to their postings. BBcode tags are a safe way of adding markup (bold, italic, images, links, etc.).
-version: 2.0.11
+version: 2.0.12
 author: Phorum Dev Team
 url: http://www.phorum.org/
 

--- a/pm.php
+++ b/pm.php
@@ -1485,7 +1485,7 @@ function phorum_pm_quoteformat($orig_author, $orig_author_id, $message, $inreply
     if (empty($quote) || is_array($quote))
     {
         // Build a quoted version of the message body.
-        $quote = phorum_strip_body($message["message"]);
+        $quote = phorum_strip_body($message["message"], true, $PHORUM["strip_quote_posting_form"]);
         $quote = str_replace("\n", "\n> ", $quote);
         $quote = wordwrap(trim($quote), 50, "\n> ", true);
         $quote = "$author {$PHORUM['DATA']['LANG']['Wrote']}:\n" .


### PR DESCRIPTION
New "General Settings" for stripping HTML and BBCode <tags> when quoting or mailing messages ( see http://www.phorum.org/phorum5/read.php?14,130238 )

BBCode Module now  uses the corresponding core function for stripping message body (optional stripping HTML and BBCode <tags>, replacing bad words) when quoting a message. Module version changed to 2.0.12.

Fixed some wrong function documentation.

Fixed some quotes and apostrophe to corresponding HTML entities.

Phorum version changed to 5.2.21.