### PR TITLE
Group Membership filtering not working

### DIFF
--- a/include/controlcenter/groupmod.php
+++ b/include/controlcenter/groupmod.php
@@ -17,27 +17,27 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-if (!defined("PHORUM_CONTROL_CENTER")) return;
+if (!defined('PHORUM_CONTROL_CENTER')) return;
 
 if(isset($PHORUM['args']['group'])){
     $group_id = (int) $PHORUM['args']['group'];
 
-} else if(isset($_POST["group"])){
-    $group_id = (int) $_POST["group"];
+} else if(isset($_POST['group'])){
+    $group_id = (int) $_POST['group'];
 
 } else {
-    $group_id = "";
+    $group_id = '';
 }
 
 if(isset($PHORUM['args']['filter'])){
     $filter = $PHORUM['args']['filter'];
-} else if(isset($_POST["filter"])){
-    $filter = $_POST["filter"];
+} else if(isset($_POST['filter'])){
+    $filter = $_POST['filter'];
 } else {
-    $filter = "all";
+    $filter = 'all';
 }
 
-// only allowed values are "all" or integers
+// only allowed values are 'all' or integers
 if($filter !== 'all') {
     $filter = (int) $filter;
 }
@@ -50,7 +50,7 @@ if (!empty($group_id)) {
 // Otherwise, we are just interested if the user is a group moderator or not.
 // The GROUP_MODERATOR variable is set from control.php.
 else{
-    $perm = $PHORUM["DATA"]["GROUP_MODERATOR"];
+    $perm = $PHORUM['DATA']['GROUP_MODERATOR'];
 }
 
 if (!$perm) {
@@ -61,21 +61,21 @@ if (!$perm) {
 if (!empty($group_id))
 {
     // if adding a new user to the group
-    if (isset($_REQUEST["adduser"])){
+    if (isset($_REQUEST['adduser'])){
 
         // Find the user_id for the user to add.
-        if(is_numeric($_REQUEST["adduser"])){
+        if(is_numeric($_REQUEST['adduser'])){
             // fix implemented 11/16/08
-            $userid = (int)$_REQUEST["adduser"];
+            $userid = (int)$_REQUEST['adduser'];
         } else {
             // older templates may send username
-            $name = trim($_REQUEST["adduser"]);
+            $name = trim($_REQUEST['adduser']);
             if ($name != '') {
 
-                if($PHORUM["display_name_source"] == "username"){
-                    $check_fields = array("username", "real_name");
+                if($PHORUM['display_name_source'] == 'username'){
+                    $check_fields = array('username', 'real_name');
                 } else {
-                    $check_fields = array("real_name", "username");
+                    $check_fields = array('real_name', 'username');
                 }
 
                 foreach($check_fields as $field){
@@ -98,64 +98,64 @@ if (!empty($group_id))
             if (!isset($groups[$group_id])){
                 $groups[$group_id] = PHORUM_USER_GROUP_APPROVED;
                 phorum_api_user_save_groups($userid, $groups);
-                $PHORUM["DATA"]["OKMSG"] = $PHORUM["DATA"]["LANG"]["UserAddedToGroup"];
+                $PHORUM['DATA']['OKMSG'] = $PHORUM['DATA']['LANG']['UserAddedToGroup'];
             }
         } elseif (!empty($userids) && count($userids) > 1) {
-            $PHORUM["DATA"]["ERROR"] = $PHORUM["DATA"]["LANG"]["DupUserFound"];
+            $PHORUM['DATA']['ERROR'] = $PHORUM['DATA']['LANG']['DupUserFound'];
         } else {
-            $PHORUM["DATA"]["ERROR"] = $PHORUM["DATA"]["LANG"]["UserNotFoundGroup"];
+            $PHORUM['DATA']['ERROR'] = $PHORUM['DATA']['LANG']['UserNotFoundGroup'];
         }
     }
 
     // if changing the existing members of the group
-    if (isset($_REQUEST["status"])){
-        foreach ($_REQUEST["status"] as $userid => $status){
+    if (isset($_REQUEST['status'])){
+        foreach ($_REQUEST['status'] as $userid => $status){
             // load the user's groups, make the change, then save again
             $groups = phorum_api_user_check_group_access(PHORUM_USER_GROUP_SUSPENDED, PHORUM_ACCESS_LIST, $userid);
             // we can't set someone to be a moderator from here
             if ($status != PHORUM_USER_GROUP_MODERATOR){
                 $groups[$group_id] = $status;
             }
-            if ($status == "remove"){
+            if ($status == 'remove'){
                 unset($groups[$group_id]);
             }
             phorum_api_user_save_groups($userid, $groups);
         }
-        $PHORUM["DATA"]["OKMSG"] = $PHORUM["DATA"]["LANG"]["ChangesSaved"];
+        $PHORUM['DATA']['OKMSG'] = $PHORUM['DATA']['LANG']['ChangesSaved'];
     }
 
     $group = $PHORUM['DB']->get_groups($group_id);
-    $PHORUM["DATA"]["GROUP"]["id"] = $group_id;
-    $PHORUM["DATA"]["GROUP"]["name"] = $group[$group_id]["name"];
-    $PHORUM["DATA"]["USERS"] = array();
-    $PHORUM["DATA"]["GROUP"]["URL"]["VIEW"] = phorum_api_url(PHORUM_CONTROLCENTER_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id);
+    $PHORUM['DATA']['GROUP']['id'] = $group_id;
+    $PHORUM['DATA']['GROUP']['name'] = $group[$group_id]['name'];
+    $PHORUM['DATA']['USERS'] = array();
+    $PHORUM['DATA']['GROUP']['URL']['VIEW'] = phorum_api_url(PHORUM_CONTROLCENTER_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id);
 
-    $PHORUM["DATA"]["FILTER"] = array();
-    $PHORUM["DATA"]["FILTER"][] = array("name" => $PHORUM["DATA"]["LANG"]["ShowAll"],
-        "enable" => $filter == "all",
-        "url" => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id),
-        "id" => "all");
-    $PHORUM["DATA"]["FILTER"][] = array("name" => $PHORUM["DATA"]["LANG"]["ShowApproved"],
-        "enable" => $filter == PHORUM_USER_GROUP_APPROVED,
-        "url" => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id, "filter=" . PHORUM_USER_GROUP_APPROVED),
-        "id" => PHORUM_USER_GROUP_APPROVED);
-    $PHORUM["DATA"]["FILTER"][] = array("name" => $PHORUM["DATA"]["LANG"]["ShowGroupModerator"],
-        "enable" => $filter == PHORUM_USER_GROUP_MODERATOR,
-        "url" => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id, "filter=" . PHORUM_USER_GROUP_MODERATOR),
-        "id" => PHORUM_USER_GROUP_MODERATOR);
-    $PHORUM["DATA"]["FILTER"][] = array("name" => $PHORUM["DATA"]["LANG"]["ShowSuspended"],
-        "enable" => $filter == PHORUM_USER_GROUP_SUSPENDED,
-        "url" => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id, "filter=" . PHORUM_USER_GROUP_SUSPENDED),
-        "id" => PHORUM_USER_GROUP_SUSPENDED);
-    $PHORUM["DATA"]["FILTER"][] = array("name" => $PHORUM["DATA"]["LANG"]["ShowUnapproved"],
-        "enable" => $filter != "all" && $filter == PHORUM_USER_GROUP_UNAPPROVED,
-        "url" => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $group_id, "filter=" . PHORUM_USER_GROUP_UNAPPROVED),
-        "id" => PHORUM_USER_GROUP_UNAPPROVED);
-    $PHORUM["DATA"]["STATUS_OPTIONS"] = array();
-    $PHORUM["DATA"]["STATUS_OPTIONS"][] = array("value" => "remove", "name" => "&lt; " . $PHORUM["DATA"]["LANG"]["RemoveFromGroup"] . " &gt;");
-    $PHORUM["DATA"]["STATUS_OPTIONS"][] = array("value" => PHORUM_USER_GROUP_APPROVED, "name" => $PHORUM["DATA"]["LANG"]["Approved"]);
-    $PHORUM["DATA"]["STATUS_OPTIONS"][] = array("value" => PHORUM_USER_GROUP_UNAPPROVED, "name" => $PHORUM["DATA"]["LANG"]["Unapproved"]);
-    $PHORUM["DATA"]["STATUS_OPTIONS"][] = array("value" => PHORUM_USER_GROUP_SUSPENDED, "name" => $PHORUM["DATA"]["LANG"]["Suspended"]);
+    $PHORUM['DATA']['FILTER'] = array();
+    $PHORUM['DATA']['FILTER'][] = array('name' => $PHORUM['DATA']['LANG']['ShowAll'],
+        'enable' => $filter === 'all',
+        'url' => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id),
+        'id' => 'all');
+    $PHORUM['DATA']['FILTER'][] = array('name' => $PHORUM['DATA']['LANG']['ShowApproved'],
+        'enable' => $filter == PHORUM_USER_GROUP_APPROVED,
+        'url' => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id, 'filter=' . PHORUM_USER_GROUP_APPROVED),
+        'id' => PHORUM_USER_GROUP_APPROVED);
+    $PHORUM['DATA']['FILTER'][] = array('name' => $PHORUM['DATA']['LANG']['ShowGroupModerator'],
+        'enable' => $filter == PHORUM_USER_GROUP_MODERATOR,
+        'url' => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id, 'filter=' . PHORUM_USER_GROUP_MODERATOR),
+        'id' => PHORUM_USER_GROUP_MODERATOR);
+    $PHORUM['DATA']['FILTER'][] = array('name' => $PHORUM['DATA']['LANG']['ShowSuspended'],
+        'enable' => $filter == PHORUM_USER_GROUP_SUSPENDED,
+        'url' => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id, 'filter=' . PHORUM_USER_GROUP_SUSPENDED),
+        'id' => PHORUM_USER_GROUP_SUSPENDED);
+    $PHORUM['DATA']['FILTER'][] = array('name' => $PHORUM['DATA']['LANG']['ShowUnapproved'],
+        'enable' => $filter !== 'all' && $filter == PHORUM_USER_GROUP_UNAPPROVED,
+        'url' => phorum_api_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $group_id, 'filter=' . PHORUM_USER_GROUP_UNAPPROVED),
+        'id' => PHORUM_USER_GROUP_UNAPPROVED);
+    $PHORUM['DATA']['STATUS_OPTIONS'] = array();
+    $PHORUM['DATA']['STATUS_OPTIONS'][] = array('value' => 'remove', 'name' => '&lt; ' . $PHORUM['DATA']['LANG']['RemoveFromGroup'] . ' &gt;');
+    $PHORUM['DATA']['STATUS_OPTIONS'][] = array('value' => PHORUM_USER_GROUP_APPROVED, 'name' => $PHORUM['DATA']['LANG']['Approved']);
+    $PHORUM['DATA']['STATUS_OPTIONS'][] = array('value' => PHORUM_USER_GROUP_UNAPPROVED, 'name' => $PHORUM['DATA']['LANG']['Unapproved']);
+    $PHORUM['DATA']['STATUS_OPTIONS'][] = array('value' => PHORUM_USER_GROUP_SUSPENDED, 'name' => $PHORUM['DATA']['LANG']['Suspended']);
 
     $groupmembers = $PHORUM['DB']->get_group_members($group_id);
     $usersingroup = array_keys($groupmembers);
@@ -163,46 +163,46 @@ if (!empty($group_id))
     $memberlist = array();
     foreach ($groupmembers as $userid => $status){
         // if we have a filter, check that the user is in it
-        if ($filter != "all"){
+        if ($filter !== 'all'){
             if ($filter != $status){
                 continue;
             }
         }
 
         $disabled = false;
-        $statustext = "";
+        $statustext = '';
         // moderators can't edit other moderators
         if ($status == PHORUM_USER_GROUP_MODERATOR){
             $disabled = true;
-            $statustext = $PHORUM["DATA"]["LANG"]["PermGroupModerator"];
+            $statustext = $PHORUM['DATA']['LANG']['PermGroupModerator'];
         }
 
-        $PHORUM["DATA"]["USERS"][$userid] = array("userid" => $userid,
-            "name" => htmlspecialchars($users[$userid]["username"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]),
-            "display_name" => (empty($PHORUM["custom_display_name"])
-                            ? htmlspecialchars($users[$userid]["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
-                            : $users[$userid]["display_name"]),
-            "status" => $status,
-            "statustext" => $statustext,
-            "disabled" => $disabled,
-            "flag" => ($status < PHORUM_USER_GROUP_APPROVED),
-            "url" => phorum_api_url(PHORUM_PROFILE_URL, $userid)
+        $PHORUM['DATA']['USERS'][$userid] = array('userid' => $userid,
+            'name' => htmlspecialchars($users[$userid]['username'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']),
+            'display_name' => (empty($PHORUM['custom_display_name'])
+                            ? htmlspecialchars($users[$userid]['display_name'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET'])
+                            : $users[$userid]['display_name']),
+            'status' => $status,
+            'statustext' => $statustext,
+            'disabled' => $disabled,
+            'flag' => ($status < PHORUM_USER_GROUP_APPROVED),
+            'url' => phorum_api_url(PHORUM_PROFILE_URL, $userid)
             );
     }
 
-    if (isset($PHORUM["hooks"]["user_list"]))
-        $PHORUM["DATA"]["USERS"] = phorum_api_hook("user_list", $PHORUM["DATA"]["USERS"]);
+    if (isset($PHORUM['hooks']['user_list']))
+        $PHORUM['DATA']['USERS'] = phorum_api_hook('user_list', $PHORUM['DATA']['USERS']);
 
     // if the option to build a dropdown list is enabled, build the list of members that could be added
-    if ($PHORUM["enable_dropdown_userlist"]){
+    if ($PHORUM['enable_dropdown_userlist']){
         $userlist = phorum_api_user_list(PHORUM_GET_ACTIVE);
-        $PHORUM["DATA"]["NEWMEMBERS"] = array();
+        $PHORUM['DATA']['NEWMEMBERS'] = array();
 
         foreach ($userlist as $userid => $userinfo){
             if (!in_array($userid, $usersingroup)){
-                $userinfo["username"] = htmlspecialchars($userinfo["username"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
-                $userinfo["display_name"] = htmlspecialchars($userinfo["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
-                $PHORUM["DATA"]["NEWMEMBERS"][] = $userinfo;
+                $userinfo['username'] = htmlspecialchars($userinfo['username'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+                $userinfo['display_name'] = htmlspecialchars($userinfo['display_name'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+                $PHORUM['DATA']['NEWMEMBERS'][] = $userinfo;
             }
         }
     }
@@ -211,7 +211,7 @@ if (!empty($group_id))
 
 // if they aren't doing anything, show them a list of groups they can moderate
 else{
-    $PHORUM["DATA"]["GROUPS"] = array();
+    $PHORUM['DATA']['GROUPS'] = array();
     $groups = phorum_api_user_check_group_access(PHORUM_USER_GROUP_MODERATOR, PHORUM_ACCESS_LIST);
     // Turn the groups into a group id => group name mapping.
     foreach ($groups as $id => $group) $groups[$id] = $group['name'];
@@ -223,20 +223,20 @@ else{
         $members = $PHORUM['DB']->get_group_members($groupid, PHORUM_USER_GROUP_UNAPPROVED);
         $full_members = $PHORUM['DB']->get_group_members($groupid);
 
-        $PHORUM["DATA"]["GROUPS"][] = array(
-            "id" => $groupid,
-            "name" => $groupname,
-            "unapproved" => count($members),
-            "members" => count($full_members),
-            "URL" => array(
-                "VIEW" => phorum_api_url(PHORUM_CONTROLCENTER_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $groupid),
-                "UNAPPROVED" => phorum_api_url(PHORUM_CONTROLCENTER_URL, "panel=" . PHORUM_CC_GROUP_MODERATION,  "group=" . $groupid, "filter=" . PHORUM_USER_GROUP_UNAPPROVED)
+        $PHORUM['DATA']['GROUPS'][] = array(
+            'id' => $groupid,
+            'name' => $groupname,
+            'unapproved' => count($members),
+            'members' => count($full_members),
+            'URL' => array(
+                'VIEW' => phorum_api_url(PHORUM_CONTROLCENTER_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $groupid),
+                'UNAPPROVED' => phorum_api_url(PHORUM_CONTROLCENTER_URL, 'panel=' . PHORUM_CC_GROUP_MODERATION, 'group=' . $groupid, 'filter=' . PHORUM_USER_GROUP_UNAPPROVED)
             )
         );
     }
 }
 
-$PHORUM["DATA"]['POST_VARS'].="<input type=\"hidden\" name=\"group\" value=\"$group_id\" />\n";
+$PHORUM['DATA']['POST_VARS'].="<input type=\"hidden\" name=\"group\" value=\"$group_id\" />\n";
 
-$template = "cc_groupmod";
+$template = 'cc_groupmod';
 ?>


### PR DESCRIPTION
When moderators use Group Membership, in control panel, to filter on
users awaiting approval, the page refreshes to "all users". See:
http://www.phorum.org/phorum5/read.php?61,156480