### PR TITLE
Change require_once to use PHPMailerAutoload.php

### DIFF
--- a/mods/smtp_mail/smtp_mail.php
+++ b/mods/smtp_mail/smtp_mail.php
@@ -35,7 +35,7 @@ function phorum_smtp_send_messages ($data)
 
         try {
 
-            require_once("./mods/smtp_mail/phpmailer/class.phpmailer.php");
+            require_once("./mods/smtp_mail/phpmailer/PHPMailerAutoload.php");
 
             $mail = new PHPMailer();
             $mail->PluginDir = "./mods/smtp_mail/phpmailer/";


### PR DESCRIPTION
As per PHPMailer/PHPMailer#113

"PHP Fatal error:  Class 'SMTP' not found" will be caused when using class.phpmailer.php