### PR TITLE
Replace ENT_COMPAT by ENT_QUOTES

### DIFF
--- a/addon.php
+++ b/addon.php
@@ -120,7 +120,7 @@ foreach ($avail_hooks["mods"] as $id => $checkmodule) {
 if (count($filtered_hooks["mods"]) == 0) trigger_error(
     '<h1>Modscript Error</h1>' .
     'No addon hook enabled for module "' .
-    htmlspecialchars($module, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) . '"',
+    phorum_api_format_htmlspecialchars($module) . '"',
     E_USER_ERROR
 );
 
@@ -128,7 +128,7 @@ if (count($filtered_hooks["mods"]) > 1) trigger_error(
     '<h1>Modsript Error</h1>' .
     'More than one addon hook was registered ' .
     'in the info for module "' .
-    htmlspecialchars($module, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) .
+    phorum_api_format_htmlspecialchars($module) .
     '".<br/>Only one addon hook is allowed per module.',
     E_USER_ERROR
 );

--- a/changes.php
+++ b/changes.php
@@ -75,7 +75,7 @@ foreach($diffs as $diff_info){
 
     if(!isset($diff_info["user_id"])){
         $this_version["username"] = empty($PHORUM['custom_display_name'])
-                                  ? htmlspecialchars($message["author"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                                  ? phorum_api_format_htmlspecialchars($message["author"])
                                   : $message["author"];
         $this_version["user_id"] = $message["user_id"];
         $this_version["date"] = phorum_api_format_date($PHORUM["long_date_time"], $message["datestamp"]);
@@ -85,7 +85,7 @@ foreach($diffs as $diff_info){
         $edit_user = phorum_api_user_get($diff_info['user_id']);
 
         $this_version["username"] = empty($PHORUM['custom_display_name'])
-                                  ? htmlspecialchars($edit_user["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                                  ? phorum_api_format_htmlspecialchars($edit_user["display_name"])
                                   : $edit_user["display_name"];
         $this_version["user_id"] = $diff_info["user_id"];
         $this_version["date"] = phorum_api_format_date($PHORUM["long_date_time"], $diff_info["time"]);
@@ -103,7 +103,7 @@ foreach($diffs as $diff_info){
         $colored_body = phorum_api_diff_unpatch_color($prev_body, $diff_info['diff_body']);
         $prev_body = phorum_api_diff_unpatch($prev_body, $diff_info['diff_body']);
 
-        $colored_body = htmlspecialchars($colored_body, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+        $colored_body = phorum_api_format_htmlspecialchars($colored_body);
         $colored_body = str_replace(
                         array("[phorum addition]", "[phorum removal]", "[/phorum addition]", "[/phorum removal]"),
                         array("<span class=\"addition\">", "<span class=\"removal\">", "</span>", "</span>"),
@@ -133,7 +133,7 @@ foreach($diffs as $diff_info){
         $colored_subject = phorum_api_diff_unpatch_color($prev_subject, $diff_info['diff_subject']);
         $prev_subject = phorum_api_diff_unpatch($prev_subject, $diff_info['diff_subject']);
 
-        $colored_subject = htmlspecialchars($colored_subject, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+        $colored_subject = phorum_api_format_htmlspecialchars($colored_subject);
         $colored_subject = str_replace(
                         array("[phorum addition]", "[phorum removal]", "[/phorum addition]", "[/phorum removal]"),
                         array("<span class=\"addition\">", "<span class=\"removal\">", "</span>", "</span>"),
@@ -161,7 +161,7 @@ foreach($diffs as $diff_info){
 $PHORUM["DATA"]["HEADING"] = $PHORUM["DATA"]["LANG"]["ChangeHistory"];
 // unset default description
 $PHORUM["DATA"]["DESCRIPTION"] = "";
-$PHORUM["DATA"]["MESSAGE"]["subject"] = htmlspecialchars($message["subject"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+$PHORUM["DATA"]["MESSAGE"]["subject"] = phorum_api_format_htmlspecialchars($message["subject"]);
 $PHORUM["DATA"]["MESSAGE"]["URL"]["READ"] = phorum_api_url(PHORUM_READ_URL, $message["thread"], $message_id);
 $PHORUM["DATA"]["CHANGES"] = $message_hist;
 

--- a/control.php
+++ b/control.php
@@ -33,7 +33,7 @@ define("PHORUM_CONTROL_CENTER", 1);
 
 $error_msg = false;
 $error = "";
-$okmsg = isset($PHORUM['args']['okmsg']) ? htmlspecialchars($PHORUM['args']['okmsg'], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) : "";
+$okmsg = isset($PHORUM['args']['okmsg']) ? phorum_api_format_htmlspecialchars($PHORUM['args']['okmsg']) : "";
 $template = "";
 
 // Generating the panel id of the page to use.
@@ -47,9 +47,7 @@ if(isset($PHORUM['args']['panel'])){
     $panel = PHORUM_CC_SUMMARY;
 }
 
-$panel = htmlspecialchars(
-    basename($panel), ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]
-);
+$panel = phorum_api_format_htmlspecialchars(basename($panel));
 
 // Set all our URLs.
 phorum_build_common_urls();
@@ -111,12 +109,12 @@ $user["signature_formatted"] = $fake_messages[0]["body"];
 
 // Format the user signature using standard message body formatting
 // or  HTML escape it
-$user["signature"] = htmlspecialchars($user["signature"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+$user["signature"] = phorum_api_format_htmlspecialchars($user["signature"]);
 
 // HTML escape all other fields that are used in the control center.
 foreach ($user as $key => $val) {
   if (is_array($val) || substr($key, 0, 9) == 'signature') continue;
-  $user[$key] = htmlspecialchars($user[$key], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+  $user[$key] = phorum_api_format_htmlspecialchars($user[$key]);
 }
 
 // Initialize any custom profile fields that are not present.
@@ -387,10 +385,10 @@ function phorum_controlcenter_user_save($panel)
 
                     // Format the user signature using standard message body formatting
                     // or  HTML escape it
-                    $PHORUM["DATA"]["PROFILE"]["signature"] = htmlspecialchars($PHORUM["user"]["signature"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                    $PHORUM["DATA"]["PROFILE"]["signature"] = phorum_api_format_htmlspecialchars($PHORUM["user"]["signature"]);
                  } else {
                     // same handling as when loading the page for the first time
-                    $PHORUM["DATA"]["PROFILE"][$key] = htmlspecialchars($PHORUM["user"][$key], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+                    $PHORUM["DATA"]["PROFILE"][$key] = phorum_api_format_htmlspecialchars($PHORUM["user"][$key]);
                  }
             } else {
                 $PHORUM["DATA"]["PROFILE"][$key] = "";

--- a/include/admin/login.php
+++ b/include/admin/login.php
@@ -74,7 +74,7 @@ $frm = new PhorumInputForm ("", "post");
 
 if(!empty($_SERVER["QUERY_STRING"])){
 
-    $frm->hidden("target", htmlspecialchars($_SERVER["QUERY_STRING"], ENT_COMPAT, $PHORUM["DATA"]['CHARSET']));
+    $frm->hidden("target", phorum_api_format_htmlspecialchars($_SERVER["QUERY_STRING"]));
 
 }
 

--- a/include/api.php
+++ b/include/api.php
@@ -293,6 +293,7 @@ require_once PHORUM_PATH . '/include/api/redirect.php';
 require_once PHORUM_PATH . '/include/api/user.php';
 require_once PHORUM_PATH . '/include/api/forums.php';
 require_once PHORUM_PATH . '/include/api/format.php';
+require_once PHORUM_PATH . '/include/api/format/htmlspecialchars.php';
 require_once PHORUM_PATH . '/include/api/format/users.php';
 require_once PHORUM_PATH . '/include/api/format/wordwrap.php';
 require_once PHORUM_PATH . '/include/api/template.php';
@@ -383,7 +384,7 @@ if (function_exists('phorum_api_cache_check'))
              "configuration is okay, check if the application used " .
              "for caching is running.<br/><br/>" .
              "The error as returned by the cache layer is:<br/>" .
-             "<b>" . htmlspecialchars($error) . "</b>";
+             "<b>" . phorum_api_format_htmlspecialchars($error) . "</b>";
         exit();
     }
 }

--- a/include/api/error/database.php
+++ b/include/api/error/database.php
@@ -38,7 +38,6 @@ require_once PHORUM_PATH.'/include/api/error/backtrace.php';
 function phorum_api_error_database($error)
 {
     global $PHORUM;
-    $hcharset = $PHORUM['DATA']['HCHARSET'];
 
     // Clear any output that we buffered so far (e.g. in the admin interface,
     // we might already have sent the page header).
@@ -121,7 +120,7 @@ function phorum_api_error_database($error)
         // error message inside a comment in the page.
         if (defined("PHORUM_ADMIN")) {
             print "<!-- " .
-                  htmlspecialchars($error, ENT_COMPAT, $hcharset) .
+                  phorum_api_format_htmlspecialchars($error) .
                   " -->";
         }
     }
@@ -178,11 +177,11 @@ function phorum_api_error_database($error)
                 $htmlbacktrace =
                     $backtrace === NULL
                     ? NULL
-                    : nl2br(htmlspecialchars($backtrace, ENT_COMPAT, $hcharset));
+                    : nl2br(phorum_api_format_htmlspecialchars($backtrace));
 
                 print "Please try again later!" .
                       "<h3>Error:</h3>" .
-                      htmlspecialchars($error, ENT_COMPAT, $hcharset) .
+                      phorum_api_format_htmlspecialchars($error) .
                       ($backtrace !== NULL
                        ? "<h3>Backtrace:</h3>\n$htmlbacktrace"
                        : "");
@@ -196,7 +195,7 @@ function phorum_api_error_database($error)
             $data = array(
               'mailmessage' =>
                   "A database error occured in your Phorum installation\n" .
-                  htmlspecialchars($PHORUM['http_path']) . ":\n" .
+                  phorum_api_format_htmlspecialchars($PHORUM['http_path']) . ":\n" .
                   "\n" .
                   "Error message:\n" .
                   "--------------\n" .

--- a/include/api/feed/atom.php
+++ b/include/api/feed/atom.php
@@ -57,14 +57,12 @@ function phorum_api_feed_atom($messages, $forums, $url, $title, $description, $r
 {
     global $PHORUM;
 
-    $hcharset    = $PHORUM['DATA']['HCHARSET'];
-
-    $selfurl     = htmlspecialchars(phorum_api_url_current(), ENT_COMPAT, $hcharset);
-    $url         = htmlspecialchars($url, ENT_COMPAT, $hcharset);
-    $title       = htmlspecialchars($title, ENT_COMPAT, $hcharset);
-    $description = htmlspecialchars($description, ENT_COMPAT, $hcharset);
-    $builddate   = htmlspecialchars(date('r'), ENT_COMPAT, $hcharset);
-    $generator   = htmlspecialchars('Phorum '.PHORUM, ENT_COMPAT, $hcharset);
+    $selfurl     = phorum_api_format_htmlspecialchars(phorum_api_url_current());
+    $url         = phorum_api_format_htmlspecialchars($url);
+    $title       = phorum_api_format_htmlspecialchars($title);
+    $description = phorum_api_format_htmlspecialchars($description);
+    $builddate   = phorum_api_format_htmlspecialchars(date('r'));
+    $generator   = phorum_api_format_htmlspecialchars('Phorum '.PHORUM);
 
     $buffer = "<?xml version=\"1.0\" encoding=\"{$PHORUM['DATA']['CHARSET']}\"?>\n";
     $buffer.= "<feed xmlns=\"http://www.w3.org/2005/Atom\">\n";
@@ -113,21 +111,21 @@ function phorum_api_feed_atom($messages, $forums, $url, $title, $description, $r
         }
 
         // Generate the URL for reading the message.
-        $url = htmlspecialchars(phorum_api_url(
+        $url = phorum_api_format_htmlspecialchars(phorum_api_url(
             PHORUM_FOREIGN_READ_URL,
             $message["forum_id"], $message["thread"], $message["message_id"]
         ));
 
         // The forum in which the message is stored is used as the category.
-        $category = htmlspecialchars(
-            $forums[$message['forum_id']]['name'], ENT_COMPAT, $hcharset
+        $category = phorum_api_format_htmlspecialchars(
+            $forums[$message['forum_id']]['name']
         );
 
         // Format the author.
         $author = !empty($users[$message['user_id']])
                 ? $users[$message['user_id']]
                 : $message['author'];
-        $author = htmlspecialchars($author, ENT_COMPAT, $hcharset);
+        $author = phorum_api_format_htmlspecialchars($author);
 
         // Strip unprintable characters from the message body.
         $body = strtr($message['body'],

--- a/include/api/feed/html.php
+++ b/include/api/feed/html.php
@@ -57,12 +57,11 @@
 function phorum_api_feed_html($messages, $forums, $url, $title, $description, $replies)
 {
     global $PHORUM;
-    $hcharset    = $PHORUM['DATA']['HCHARSET'];
 
-    $url         = htmlspecialchars($url, ENT_COMPAT, $hcharset);
-    $title       = htmlspecialchars($title, ENT_COMPAT, $hcharset);
-    $description = htmlspecialchars($description, ENT_COMPAT, $hcharset);
-    $builddate   = htmlspecialchars(date('r'), ENT_COMPAT, $hcharset);
+    $url         = phorum_api_format_htmlspecialchars($url);
+    $title       = phorum_api_format_htmlspecialchars($title);
+    $description = phorum_api_format_htmlspecialchars($description);
+    $builddate   = phorum_api_format_htmlspecialchars(date('r'));
 
     $buffer = "<div id=\"phorum_feed\">\n";
     $buffer.= " <div id=\"phorum_feed_title\">\n";
@@ -75,7 +74,7 @@ function phorum_api_feed_html($messages, $forums, $url, $title, $description, $r
 
     foreach($messages as $message)
     {
-        $title = htmlspecialchars(strip_tags($message["subject"]), ENT_COMPAT, $hcharset);
+        $title = phorum_api_format_htmlspecialchars(strip_tags($message["subject"]));
         if (!$replies)
         {
             $lang = $PHORUM['DATA']['LANG'];
@@ -89,13 +88,13 @@ function phorum_api_feed_html($messages, $forums, $url, $title, $description, $r
 
         }
 
-        $url = htmlspecialchars(phorum_api_url(
+        $url = phorum_api_format_htmlspecialchars(phorum_api_url(
             PHORUM_FOREIGN_READ_URL,
             $message["forum_id"], $message["thread"], $message["message_id"]
         ));
 
-        $body = substr(htmlspecialchars(
-            phorum_api_format_strip($message['body']), ENT_COMPAT, $hcharset
+        $body = substr(phorum_api_format_htmlspecialchars(
+            phorum_api_format_strip($message['body'])
         ), 0, 200);
 
         $buffer.= "  <li><a href=\"$url\" title=\"$body\">$title</a></li>\n";

--- a/include/api/feed/rss.php
+++ b/include/api/feed/rss.php
@@ -58,12 +58,11 @@ function phorum_api_feed_rss($messages, $forums, $url, $title, $description, $re
 {
     global $PHORUM;
 
-    $hcharset    = $PHORUM['DATA']['HCHARSET'];
-    $url         = htmlspecialchars($url, ENT_COMPAT, $hcharset);
-    $title       = htmlspecialchars($title, ENT_COMPAT, $hcharset);
-    $description = htmlspecialchars($description, ENT_COMPAT, $hcharset);
-    $builddate   = htmlspecialchars(date('r'), ENT_COMPAT, $hcharset);
-    $generator   = htmlspecialchars('Phorum '.PHORUM, ENT_COMPAT, $hcharset);
+    $url         = phorum_api_format_htmlspecialchars($url);
+    $title       = phorum_api_format_htmlspecialchars($title);
+    $description = phorum_api_format_htmlspecialchars($description);
+    $builddate   = phorum_api_format_htmlspecialchars(date('r'));
+    $generator   = phorum_api_format_htmlspecialchars('Phorum '.PHORUM);
 
     $buffer = "<?xml version=\"1.0\" encoding=\"{$PHORUM['DATA']['CHARSET']}\"?>\n";
     $buffer.= "<rss version=\"2.0\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n";
@@ -104,21 +103,19 @@ function phorum_api_feed_rss($messages, $forums, $url, $title, $description, $re
         }
 
         // Generate the URL for reading the message.
-        $url = htmlspecialchars(phorum_api_url(
+        $url = phorum_api_format_htmlspecialchars(phorum_api_url(
             PHORUM_FOREIGN_READ_URL,
             $message["forum_id"], $message["thread"], $message["message_id"]
         ));
 
         // The forum in which the message is stored is used as the category.
-        $category = htmlspecialchars(
-            $forums[$message['forum_id']]['name'], ENT_COMPAT, $hcharset
-        );
+        $category = phorum_api_format_htmlspecialchars($forums[$message['forum_id']]['name']);
 
         // Format the author.
         $author = !empty($users[$message['user_id']])
                 ? $users[$message['user_id']]
                 : $message['author'];
-        $author = htmlspecialchars($author, ENT_COMPAT, $hcharset);
+        $author = phorum_api_format_htmlspecialchars($author);
 
         // Strip unprintable characters from the message body.
         $body = strtr($message['body'],

--- a/include/api/format/htmlspecialchars.php
+++ b/include/api/format/htmlspecialchars.php
@@ -1,7 +1,7 @@
 <?php
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
-//   Copyright (C) 2011  Phorum Development Team                              //
+//   Copyright (C) 2016  Phorum Development Team                              //
 //   http://www.phorum.org                                                    //
 //                                                                            //
 //   This program is free software. You can redistribute it and/or modify     //
@@ -18,46 +18,31 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * This script implements user formatting.
+ * This script implements our default htmlspecialchars function.
  *
  * @package    PhorumAPI
  * @subpackage Formatting
- * @copyright  2011, Phorum Development Team
+ * @copyright  2016, Phorum Development Team
  * @license    Phorum License, http://www.phorum.org/license.txt
  */
 
-// {{{ Function: phorum_api_format_users()
+
+// {{{ Function: phorum_api_format_htmlspecialchars()
 /**
- * This function handles preparing user data for use in the templates.
+ * htmlspecialchars with default arguments.
  *
- * @param array $users
- *     An array of users that have to be formatted.
- *     Each user is an array on its own, containing the user data.
+ * @param string $string
+ *     The string being converted.
+ * @return string
+ *     The converted string.
  *
- * @return array
- *     The same as the $users argument array, with formatting applied.
+ * The related variable from the language file is:
+ * - $PHORUM['DATA']['HCHARSET']: the charset to use
  */
-function phorum_api_format_users($users)
+function phorum_api_format_htmlspecialchars( $string )
 {
     global $PHORUM;
-
-    foreach ($users as $id => $user)
-    {
-        foreach (array(
-            'username', 'real_name', 'display_name',
-            'email', 'signature'
-        ) as $field) {
-            if (isset($user[$field])) {
-                if($field == 'display_name' && !empty($PHORUM['custom_display_name'])) {
-                      $users[$id][$field] = $user[$field];
-                } else {
-                    $users[$id][$field] = phorum_api_format_htmlspecialchars($user[$field]);
-                }
-            }
-        }
-    }
-
-    return $users;
+    return htmlspecialchars($string, ENT_QUOTES, $PHORUM['DATA']['HCHARSET']);
 }
 // }}}
 

--- a/include/api/format/messages.php
+++ b/include/api/format/messages.php
@@ -109,8 +109,7 @@ function phorum_api_format_messages($messages, $author_specs = NULL)
             );
 
             // Escape special HTML characters.
-            $escaped_body = htmlspecialchars(
-                $body, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+            $escaped_body = phorum_api_format_htmlspecialchars($body);
 
             // When there is a charset mismatch between the database
             // and the language file, then bodies might get crippled
@@ -157,7 +156,7 @@ function phorum_api_format_messages($messages, $author_specs = NULL)
 
         // Escape special HTML characters.
         if (isset($message['subject'])) {
-            $messages[$id]['subject'] = htmlspecialchars($messages[$id]['subject'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+            $messages[$id]['subject'] = phorum_api_format_htmlspecialchars($messages[$id]['subject']);
         }
 
         // -----------------------------------------------------------------
@@ -166,7 +165,7 @@ function phorum_api_format_messages($messages, $author_specs = NULL)
 
         // Escape special HTML characters in the email address.
         if (isset($message['email'])) {
-            $messages[$id]['email'] = htmlspecialchars($message['email'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+            $messages[$id]['email'] = phorum_api_format_htmlspecialchars($message['email']);
         }
 
         // Do author formatting for all provided author fields.
@@ -188,7 +187,7 @@ function phorum_api_format_messages($messages, $author_specs = NULL)
                 $messages[$id]["URL"][$spec[4]] = $url;
                 $messages[$id][$spec[3]] =
                     (empty($PHORUM["custom_display_name"])
-                     ? htmlspecialchars($message[$spec[1]], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                     ? phorum_api_format_htmlspecialchars($message[$spec[1]])
                      : $message[$spec[1]]);
             }
             // For an anonymous user that left an email address.
@@ -202,13 +201,13 @@ function phorum_api_format_messages($messages, $author_specs = NULL)
                      phorum_api_user_check_access(PHORUM_USER_ALLOW_MODERATE_MESSAGES) && PHORUM_MOD_EMAIL_VIEW ||
                      phorum_api_user_check_access(PHORUM_USER_ALLOW_MODERATE_USERS) && PHORUM_MOD_EMAIL_VIEW) )
             {
-                $messages[$id][$spec[3]] = htmlspecialchars($message[$spec[1]], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $messages[$id][$spec[3]] = phorum_api_format_htmlspecialchars($message[$spec[1]]);
                 $email_url = phorum_api_format_html_encode("mailto:".$message[$spec[2]]);
                 $messages[$id]["URL"]["PROFILE"] = $email_url;
             }
             // For an anonymous user that did not leave an e-mail address.
             else {
-                $messages[$id][$spec[3]] = htmlspecialchars($message[$spec[1]], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $messages[$id][$spec[3]] = phorum_api_format_htmlspecialchars($message[$spec[1]]);
             }
 
             if ($censor_search !== NULL) {

--- a/include/api/user.php
+++ b/include/api/user.php
@@ -505,7 +505,7 @@ function phorum_api_user_save($user, $flags = 0)
             default:
                 trigger_error(
                     'phorum_api_user_save(): Illegal field type used: ' .
-                    htmlspecialchars($fldtype),
+                    phorum_api_format_htmlspecialchars($fldtype),
                     E_USER_ERROR
                 );
                 return NULL;
@@ -607,7 +607,7 @@ function phorum_api_user_save($user, $flags = 0)
     // to be provided in escaped HTML format.
     elseif (!isset($dbuser['display_name']) ||
             trim($dbuser['display_name']) == '') {
-        $dbuser['display_name'] = htmlspecialchars($dbuser['username'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+        $dbuser['display_name'] = phorum_api_format_htmlspecialchars($dbuser['username']);
     }
 
     /**
@@ -1198,7 +1198,7 @@ function phorum_api_user_get_display_name($user_id = NULL, $fallback = NULL, $fl
             // Other names do have to be escaped.
             if (empty($users[$id]) || empty($PHORUM['custom_display_name']))
             {
-                $display_name = htmlspecialchars($display_name, ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+                $display_name = phorum_api_format_htmlspecialchars($display_name);
             }
         }
         // Generate a plain text version of the display name. This is the
@@ -1664,7 +1664,7 @@ function phorum_api_user_authenticate($type, $username, $password)
         if ($authinfo['user_id']!==NULL && !is_numeric($authinfo['user_id'])) {
             trigger_error(
                 'Hook user_check_login returned a non-numerical user_id "' .
-                htmlspecialchars($authinfo['user_id']) .
+                phorum_api_format_htmlspecialchars($authinfo['user_id']) .
                 '" for the authenticated user. Phorum only supports numerical ' .
                 'user_id values.',
                 E_USER_ERROR
@@ -2072,7 +2072,7 @@ function phorum_api_user_session_create($type, $reset = 0)
         $type != PHORUM_ADMIN_SESSION) {
         trigger_error(
             'phorum_api_user_session_create(): Illegal session type: ' .
-            htmlspecialchars($type),
+            phorum_api_format_htmlspecialchars($type),
             E_USER_ERROR
         );
         return NULL;
@@ -2319,7 +2319,7 @@ function phorum_api_user_session_restore($type)
     else {
         trigger_error(
             'phorum_api_user_session_restore(): Illegal session type: ' .
-            htmlspecialchars($type),
+            phorum_api_format_htmlspecialchars($type),
             E_USER_ERROR
         );
         return NULL;
@@ -2718,7 +2718,7 @@ function phorum_api_user_session_destroy($type)
         } else {
             trigger_error(
                 'phorum_api_user_session_destroy(): Illegal session type: ' .
-                htmlspecialchars($type),
+                phorum_api_format_htmlspecialchars($type),
                 E_USER_ERROR
             );
             return NULL;
@@ -2812,7 +2812,7 @@ function phorum_api_user_save_groups($user_id, $groups)
             $perm != PHORUM_USER_GROUP_MODERATOR) {
             trigger_error(
                 'phorum_api_user_save_groups(): Illegal group permission for ' .
-                'group id '.htmlspecialchars($id).': '.htmlspecialchars($perm),
+                'group id '.phorum_api_format_htmlspecialchars($id).': '.phorum_api_format_htmlspecialchars($perm),
                 E_USER_ERROR
             );
             return NULL;

--- a/include/controlcenter/files.php
+++ b/include/controlcenter/files.php
@@ -108,8 +108,7 @@ if($PHORUM["file_space_quota"]){
 }
 
 foreach ($files as $id => $file) {
-  $files[$id]['filename'] = htmlspecialchars(
-    $file['filename'], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+  $files[$id]['filename'] = phorum_api_format_htmlspecialchars($file['filename']);
 }
 
 $PHORUM["DATA"]["FILES"] = $files;

--- a/include/controlcenter/groupmod.php
+++ b/include/controlcenter/groupmod.php
@@ -178,9 +178,9 @@ if (!empty($group_id))
         }
 
         $PHORUM['DATA']['USERS'][$userid] = array('userid' => $userid,
-            'name' => htmlspecialchars($users[$userid]['username'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']),
+            'name' => phorum_api_format_htmlspecialchars($users[$userid]['username']),
             'display_name' => (empty($PHORUM['custom_display_name'])
-                            ? htmlspecialchars($users[$userid]['display_name'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET'])
+                            ? phorum_api_format_htmlspecialchars($users[$userid]['display_name'])
                             : $users[$userid]['display_name']),
             'status' => $status,
             'statustext' => $statustext,
@@ -200,8 +200,8 @@ if (!empty($group_id))
 
         foreach ($userlist as $userid => $userinfo){
             if (!in_array($userid, $usersingroup)){
-                $userinfo['username'] = htmlspecialchars($userinfo['username'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
-                $userinfo['display_name'] = htmlspecialchars($userinfo['display_name'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+                $userinfo['username'] = phorum_api_format_htmlspecialchars($userinfo['username']);
+                $userinfo['display_name'] = phorum_api_format_htmlspecialchars($userinfo['display_name']);
                 $PHORUM['DATA']['NEWMEMBERS'][] = $userinfo;
             }
         }

--- a/include/controlcenter/users.php
+++ b/include/controlcenter/users.php
@@ -75,8 +75,8 @@ if(empty($users)){
 
     // XSS prevention.
     foreach ($users as $id => $user) {
-        $users[$id]["username"] = htmlspecialchars($user["username"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
-        $users[$id]["email"] = htmlspecialchars($user["email"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+        $users[$id]["username"] = phorum_api_format_htmlspecialchars($user["username"]);
+        $users[$id]["email"] = phorum_api_format_htmlspecialchars($user["email"]);
     }
 
     $PHORUM["DATA"]["USERS"]=$users;

--- a/include/moderation/merge_thread.php
+++ b/include/moderation/merge_thread.php
@@ -38,8 +38,7 @@ if (
     $PHORUM['DATA']['FORM']['merge_none'] = TRUE;
 
     $message = $PHORUM['DB']->get_message($msgthd_id, 'message_id', TRUE);
-    $PHORUM['DATA']['FORM']['merge_subject1'] = htmlspecialchars(
-        $message['subject'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+    $PHORUM['DATA']['FORM']['merge_subject1'] = phorum_api_format_htmlspecialchars($message['subject']);
 }
 // The moderator selects the source thread to merge from.
 else
@@ -47,12 +46,10 @@ else
     $PHORUM['DATA']['FORM']['merge_t1'] = $merge_t1;
 
     $message = $PHORUM['DB']->get_message($merge_t1, 'message_id', true);
-    $PHORUM['DATA']['FORM']['merge_subject1'] = htmlspecialchars(
-        $message['subject'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+    $PHORUM['DATA']['FORM']['merge_subject1'] = phorum_api_format_htmlspecialchars($message['subject']);
 
     $message = $PHORUM['DB']->get_message($msgthd_id);
-    $PHORUM['DATA']['FORM']['thread_subject'] = htmlspecialchars(
-        $message['subject'], ENT_COMPAT, $PHORUM['DATA']['HCHARSET']);
+    $PHORUM['DATA']['FORM']['thread_subject'] = phorum_api_format_htmlspecialchars($message['subject']);
 }
 
 ?>

--- a/include/moderation/move_thread.php
+++ b/include/moderation/move_thread.php
@@ -12,7 +12,7 @@ $PHORUM['DATA']['URL']["ACTION"]     = phorum_api_url(PHORUM_MODERATION_ACTION_U
 $PHORUM['DATA']["FORM"]["forum_id"]  = $PHORUM["forum_id"];
 $PHORUM['DATA']["FORM"]["thread_id"] = $msgthd_id;
 $PHORUM['DATA']["FORM"]["mod_step"]  = PHORUM_DO_THREAD_MOVE;
-$PHORUM['DATA']["FORM"]["subject"]   = htmlspecialchars($message["subject"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+$PHORUM['DATA']["FORM"]["subject"]   = phorum_api_format_htmlspecialchars($message["subject"]);
 
 // get all the forums the moderator may move to
 $PHORUM['DATA']["MoveForumsOption"]="";

--- a/include/moderation/split_thread.php
+++ b/include/moderation/split_thread.php
@@ -21,8 +21,8 @@ $new_subject = preg_replace('/^Re:\s*/', '', $message['subject']);
 $PHORUM['DATA']["FORM"]["forum_id"]            = $PHORUM["forum_id"];
 $PHORUM['DATA']["FORM"]["thread_id"]           = $message["thread"];
 $PHORUM['DATA']["FORM"]["message_id"]          = $msgthd_id;
-$PHORUM['DATA']["FORM"]["message_subject"]     = htmlspecialchars($message["subject"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
-$PHORUM['DATA']["FORM"]["new_message_subject"] = htmlspecialchars($new_subject, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+$PHORUM['DATA']["FORM"]["message_subject"]     = phorum_api_format_htmlspecialchars($message["subject"]);
+$PHORUM['DATA']["FORM"]["new_message_subject"] = phorum_api_format_htmlspecialchars($new_subject);
 $PHORUM['DATA']["FORM"]["mod_step"]            = PHORUM_DO_THREAD_SPLIT;
 
 $template = "split_form";

--- a/list.php
+++ b/list.php
@@ -500,7 +500,7 @@ if ($bodies_in_list)
             // unset($row["meta"]["attachments"]);
             foreach($row["attachments"] as $key=>$file){
                 $row["attachments"][$key]["size"]=phorum_api_format_filesize($file["size"]);
-                $row["attachments"][$key]["name"]=htmlspecialchars($file['name'], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $row["attachments"][$key]["name"]=phorum_api_format_htmlspecialchars($file['name']);
                 $row["attachments"][$key]["url"] =str_replace(array('%file_id%','%file_name%'),array($file['file_id'],urlencode($file['name'])),$attachment_url_template);
             }
         }

--- a/moderation.php
+++ b/moderation.php
@@ -255,11 +255,11 @@ function phorum_show_confirmation_form($message, $action, $args)
 
     ?>
     <div style="text-align: center;">
-        <strong><?php echo htmlspecialchars($message, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]); ?></strong>
+        <strong><?php echo phorum_api_format_htmlspecialchars($message); ?></strong>
         <br />
         <br />
         <form
-            action="<?php echo htmlspecialchars($action, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]); ?>"
+            action="<?php echo phorum_api_format_htmlspecialchars($action); ?>"
             method="post">
 
             <input type="hidden"
@@ -268,8 +268,8 @@ function phorum_show_confirmation_form($message, $action, $args)
 
             <?php foreach ($args as $name => $value){ ?>
                 <input type="hidden"
-                    name="<?php echo htmlspecialchars($name, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]); ?>"
-                    value="<?php echo htmlspecialchars($value, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]); ?>" />
+                    name="<?php echo phorum_api_format_htmlspecialchars($name); ?>"
+                    value="<?php echo phorum_api_format_htmlspecialchars($value); ?>" />
             <?php } ?>
 
             <?php echo $PHORUM["DATA"]["POST_VARS"]; ?>

--- a/mods/bbcode/api.php
+++ b/mods/bbcode/api.php
@@ -1081,9 +1081,8 @@ function bbcode_api_render($text, $tokens, &$message)
                         foreach ($tag[BBCODE_INFO_REPLACEARGS] as $key) {
                             $tag[BBCODE_INFO_REPLACECLOSE] = str_replace(
                                 '%'.$key.'%',
-                                htmlspecialchars(
-                                    $token[2][$key], // 2 = args
-                                    ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]
+                                phorum_api_format_htmlspecialchars(
+                                    $token[2][$key] // 2 = args
                                 ),
                                 $tag[BBCODE_INFO_REPLACECLOSE]
                             );
@@ -1118,9 +1117,8 @@ function bbcode_api_render($text, $tokens, &$message)
                         foreach ($tag[BBCODE_INFO_REPLACEARGS] as $key) {
                             $tag[BBCODE_INFO_REPLACEOPEN] = str_replace(
                                 '%'.$key.'%',
-                                htmlspecialchars(
-                                    $token[2][$key], // 2 = args
-                                    ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]
+                                phorum_api_format_htmlspecialchars(
+                                    $token[2][$key] // 2 = args
                                 ),
                                 $tag[BBCODE_INFO_REPLACEOPEN]
                             );

--- a/pm.php
+++ b/pm.php
@@ -90,7 +90,7 @@ function phorum_getparam($name, $type = NULL)
             default:
                 trigger_error(
                     "Internal error in phorum_getparam: " .
-                    "illegal type for typecasting: ".htmlspecialchars($type),
+                    "illegal type for typecasting: ".phorum_api_format_htmlspecialchars($type),
                     E_USER_ERROR
                 );
         }
@@ -565,7 +565,7 @@ if (!empty($action))
                                         $error = $PHORUM["DATA"]["LANG"]["PMToMailboxFull"];
                                         $recipient =
                                             (empty($PHORUM["custom_display_name"])
-                                             ? htmlspecialchars($user["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                                             ? phorum_api_format_htmlspecialchars($user["display_name"])
                                              : $user["display_name"]);
                                         $error = str_replace('%recipient%', $recipient, $error);
                                     }
@@ -729,7 +729,7 @@ if (!empty($action))
 
         default:
             trigger_error(
-                "Unhandled action for pm.php: " . htmlspecialchars($action),
+                "Unhandled action for pm.php: " . phorum_api_format_htmlspecialchars($action),
                 E_USER_ERROR
             );
 
@@ -789,8 +789,8 @@ switch ($page) {
     // Manage the PM folders.
     case "folders":
 
-        $PHORUM["DATA"]["CREATE_FOLDER_NAME"] = isset($_POST["create_folder_name"]) ? htmlspecialchars($_POST["create_folder_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) : '';
-        $PHORUM["DATA"]["RENAME_FOLDER_NAME"] = isset($_POST["rename_folder_name"]) ? htmlspecialchars($_POST["rename_folder_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) : '';
+        $PHORUM["DATA"]["CREATE_FOLDER_NAME"] = isset($_POST["create_folder_name"]) ? phorum_api_format_htmlspecialchars($_POST["create_folder_name"]) : '';
+        $PHORUM["DATA"]["RENAME_FOLDER_NAME"] = isset($_POST["rename_folder_name"]) ? phorum_api_format_htmlspecialchars($_POST["rename_folder_name"]) : '';
         $template = "pm_folders";
         break;
 
@@ -818,7 +818,7 @@ switch ($page) {
                 'user_id'     => $id,
                 'display_name' =>
                     (empty($PHORUM["custom_display_name"])
-                     ? htmlspecialchars($buddy_user["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                     ? phorum_api_format_htmlspecialchars($buddy_user["display_name"])
                      : $buddy_user["display_name"]),
                 'mutual'      => $buddy_list[$id]["mutual"],
             );
@@ -1210,7 +1210,7 @@ switch ($page) {
                     foreach ($val as $id => $data) {
                         $msg[$key][$id]["display_name"] =
                           (empty($PHORUM["custom_display_name"])
-                           ? htmlspecialchars($data["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                           ? phorum_api_format_htmlspecialchars($data["display_name"])
                            : $data["display_name"]);
                     }
                     break;
@@ -1218,11 +1218,11 @@ switch ($page) {
                 case "author": {
                     $msg[$key] =
                       (empty($PHORUM["custom_display_name"])
-                       ? htmlspecialchars($val, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) : $val);
+                       ? phorum_api_format_htmlspecialchars($val) : $val);
                     break;
                 }
                 default: {
-                    $msg[$key] = htmlspecialchars($val, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                    $msg[$key] = phorum_api_format_htmlspecialchars($val);
                     break;
                 }
             }
@@ -1247,7 +1247,7 @@ switch ($page) {
             $userlist = phorum_api_user_list(PHORUM_GET_ACTIVE);
             foreach ($userlist as $user_id => $userinfo){
                 if (isset($msg["recipients"][$user_id])) continue;
-                $userinfo["display_name"] = htmlspecialchars($userinfo["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $userinfo["display_name"] = phorum_api_format_htmlspecialchars($userinfo["display_name"]);
                 $userinfo["user_id"] = $user_id;
                 $allusers[] = $userinfo;
             }
@@ -1300,7 +1300,7 @@ switch ($page) {
     default:
 
         trigger_error(
-            "Illegal page requested: " . htmlspecialchars($page),
+            "Illegal page requested: " . phorum_api_format_htmlspecialchars($page),
             E_USER_ERROR
         );
 }
@@ -1334,7 +1334,7 @@ foreach($pm_folders as $id => $data)
     $pm_folders[$id]["is_special"] = is_numeric($id) ? 0 : 1;
     $pm_folders[$id]["is_outgoing"] = $id == PHORUM_PM_OUTBOX;
     $pm_folders[$id]["id"] = $id;
-    $pm_folders[$id]["name"] = htmlspecialchars($data["name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    $pm_folders[$id]["name"] = phorum_api_format_htmlspecialchars($data["name"]);
     $pm_folders[$id]["url"] = phorum_api_url(PHORUM_PM_URL, "page=list", "folder_id=$id");
 
     if (!$pm_folders[$id]["is_special"]) {
@@ -1433,7 +1433,7 @@ function phorum_pm_format($messages)
                 } else {
                     $messages[$id]["recipients"][$rcpt_id]["display_name"]=
                         (empty($PHORUM["custom_display_name"])
-                         ? htmlspecialchars($rcpt["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"])
+                         ? phorum_api_format_htmlspecialchars($rcpt["display_name"])
                          : $rcpt["display_name"]);
                     $messages[$id]["recipients"][$rcpt_id]["URL"]["PROFILE"] =
                         phorum_api_url(PHORUM_PROFILE_URL, $rcpt_id);

--- a/posting.php
+++ b/posting.php
@@ -282,7 +282,7 @@ if ($initial)
 }
 
 if (! in_array($mode, $valid_modes)) trigger_error(
-    "Illegal mode issued: " . htmlspecialchars($mode), E_USER_ERROR
+    "Illegal mode issued: " . phorum_api_format_htmlspecialchars($mode), E_USER_ERROR
 );
 
 // Find out if we are detaching an attachment.
@@ -720,7 +720,7 @@ if ($PHORUM["posting_template"] == 'posting')
             $val = base64_encode(serialize($message[$var]));
             if ($spec[pf_SIGNED]) $signval = $val;
         } else {
-            $val = htmlspecialchars($message[$var], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+            $val = phorum_api_format_htmlspecialchars($message[$var]);
             if ($spec[pf_SIGNED]) $signval = $message[$var];
         }
 
@@ -732,7 +732,7 @@ if ($PHORUM["posting_template"] == 'posting')
         if ($signval !== NULL) {
             $signature = phorum_api_sign($signval);
             $hidden .= '<input type="hidden" name="' . $var . ':signature" ' .
-                       'value="' . htmlspecialchars($signature, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]) . "\" />\n";
+                       'value="' . phorum_api_format_htmlspecialchars($signature) . "\" />\n";
         }
     }
     $PHORUM["DATA"]["POST_VARS"] .= $hidden;
@@ -760,17 +760,17 @@ if ($PHORUM["posting_template"] == 'posting')
                         continue;
                     }
 
-                    $message[$var][$nr]["name"] = htmlspecialchars($data["name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                    $message[$var][$nr]["name"] = phorum_api_format_htmlspecialchars($data["name"]);
                     $message[$var][$nr]["size"] = phorum_api_format_filesize(round($data["size"]));
                 }
             }
         } elseif ($var == "author") {
             if (empty($PHORUM["custom_display_name"])) {
-                $message[$var] = htmlspecialchars($val, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $message[$var] = phorum_api_format_htmlspecialchars($val);
             }
         } else {
             if (is_scalar($val)) {
-                $message[$var] = htmlspecialchars($val, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $message[$var] = phorum_api_format_htmlspecialchars($val);
             } else {
                 // Not used in the template, unless proven otherwise.
                 $message[$var] = '[removed from template data]';

--- a/profile.php
+++ b/profile.php
@@ -103,16 +103,16 @@ $PHORUM["DATA"]["PROFILE"]["is_buddy"] = $PHORUM['DB']->pm_is_buddy($user["user_
 $PHORUM["DATA"]["PROFILE"]["URL"]["SEARCH"] = phorum_api_url(PHORUM_SEARCH_URL, "author=".urlencode($PHORUM["DATA"]["PROFILE"]["user_id"]), "match_type=USER_ID", "match_dates=0", "match_threads=0");
 
 $PHORUM["DATA"]["PROFILE"]["username"] =
-    htmlspecialchars($PHORUM["DATA"]["PROFILE"]["username"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    phorum_api_format_htmlspecialchars($PHORUM["DATA"]["PROFILE"]["username"]);
 
 if (isset($PHORUM["DATA"]["PROFILE"]["real_name"])) {
     $PHORUM["DATA"]["PROFILE"]["real_name"] =
-        htmlspecialchars($PHORUM["DATA"]["PROFILE"]["real_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+        phorum_api_format_htmlspecialchars($PHORUM["DATA"]["PROFILE"]["real_name"]);
 }
 
 if (empty($PHORUM["custom_display_name"])) {
     $PHORUM["DATA"]["PROFILE"]["display_name"] =
-        htmlspecialchars($PHORUM["DATA"]["PROFILE"]["display_name"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+        phorum_api_format_htmlspecialchars($PHORUM["DATA"]["PROFILE"]["display_name"]);
 }
 
 if (isset($PHORUM["hooks"]["profile"])) {

--- a/read.php
+++ b/read.php
@@ -187,7 +187,7 @@ if($PHORUM['cache_messages'] &&
             $PHORUM['DATA']["URL"]["REDIRECT"]=$PHORUM["DATA"]["URL"]["LIST"];
             $PHORUM['DATA']["BACKMSG"]=$PHORUM["DATA"]["LANG"]["BackToList"];
 
-            $PHORUM["DATA"]["HTML_TITLE"] = htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+            $PHORUM["DATA"]["HTML_TITLE"] = phorum_api_format_htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"]);
             phorum_api_output("message");
             return;
         }
@@ -681,7 +681,7 @@ if(!empty($data) && isset($data[$thread]) && isset($data[$message_id])) {
             // unset($row["meta"]["attachments"]);
             foreach($row["attachments"] as $key=>$file){
                 $row["attachments"][$key]["size"] = phorum_api_format_filesize($file["size"]);
-                $row["attachments"][$key]["name"] = htmlspecialchars($file['name'], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+                $row["attachments"][$key]["name"] = phorum_api_format_htmlspecialchars($file['name']);
                 $safe_file = preg_replace('/[^\w\_\-\.]/', '_', $file['name']);
                 $safe_file = preg_replace('/_+/', '_', $safe_file);
                 $row["attachments"][$key]["url"]  = str_replace(array('%file_id%','%file_name%'),array($file['file_id'],$safe_file),$attachment_url_template);
@@ -813,7 +813,7 @@ if(!empty($data) && isset($data[$thread]) && isset($data[$message_id])) {
 
     $PHORUM["DATA"]["DESCRIPTION"] = preg_replace('!\s+!s'," ", strip_tags($PHORUM["DATA"]["TOPIC"]["body"]));
     $PHORUM["DATA"]["DESCRIPTION"] = mb_substr($PHORUM["DATA"]["DESCRIPTION"], 0, 300, $PHORUM["DATA"]["HCHARSET"]);
-    $PHORUM["DATA"]["DESCRIPTION"] = htmlspecialchars($PHORUM["DATA"]["DESCRIPTION"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    $PHORUM["DATA"]["DESCRIPTION"] = phorum_api_format_htmlspecialchars($PHORUM["DATA"]["DESCRIPTION"]);
 
     // add feed url
     if(isset($PHORUM['use_rss']) && $PHORUM['use_rss']){
@@ -886,7 +886,7 @@ elseif ($toforum=phorum_check_moved_message($thread))
     $PHORUM['DATA']["URL"]["REDIRECT"]=phorum_api_url(PHORUM_FOREIGN_READ_URL, $toforum, $thread);
     $PHORUM['DATA']["BACKMSG"]=$PHORUM["DATA"]["LANG"]["MovedMessageTo"];
 
-    $PHORUM["DATA"]["HTML_TITLE"] = htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    $PHORUM["DATA"]["HTML_TITLE"] = phorum_api_format_htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"]);
     // have to include the header here for the Redirect
     phorum_api_output("message");
 
@@ -898,7 +898,7 @@ else
     $PHORUM['DATA']["URL"]["REDIRECT"]=$PHORUM["DATA"]["URL"]["LIST"];
     $PHORUM['DATA']["BACKMSG"]=$PHORUM["DATA"]["LANG"]["BackToList"];
 
-    $PHORUM["DATA"]["HTML_TITLE"] = htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"], ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    $PHORUM["DATA"]["HTML_TITLE"] = phorum_api_format_htmlspecialchars($PHORUM["DATA"]["HTML_TITLE"]);
     // have to include the header here for the Redirect
     phorum_api_output("message");
 }

--- a/register.php
+++ b/register.php
@@ -486,7 +486,7 @@ if (count($_POST)) {
     // data to redisplay the registration form, including an error.
     if (!empty($error)) {
         foreach($_POST as $key => $val){
-            $PHORUM["DATA"]["REGISTER"][$key] = htmlspecialchars($val, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+            $PHORUM["DATA"]["REGISTER"][$key] = phorum_api_format_htmlspecialchars($val);
         }
         $PHORUM["DATA"]["ERROR"] = $error;
     }

--- a/search.php
+++ b/search.php
@@ -189,8 +189,8 @@ $allowed_forums = phorum_api_user_check_access(
 // setup some stuff based on the url passed
 if(!empty($phorum_search) || !empty($phorum_author)){
 
-    $PHORUM["DATA"]["SEARCH"]["safe_search"] = htmlspecialchars($phorum_search, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
-    $PHORUM["DATA"]["SEARCH"]["safe_author"] = htmlspecialchars($phorum_author, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+    $PHORUM["DATA"]["SEARCH"]["safe_search"] = phorum_api_format_htmlspecialchars($phorum_search);
+    $PHORUM["DATA"]["SEARCH"]["safe_author"] = phorum_api_format_htmlspecialchars($phorum_author);
 
     if(isset($PHORUM["args"]["page"])){
         $PHORUM["args"]["page"] = (int)$PHORUM["args"]["page"];
@@ -391,7 +391,7 @@ if ($PHORUM["args"]["match_type"] == "USER_ID")
     } else {
         $search_name = $search_user["display_name"];
         if (empty($PHORUM['custom_display_name'])) {
-            $search_name = htmlspecialchars($search_name, ENT_COMPAT, $PHORUM["DATA"]["HCHARSET"]);
+            $search_name = phorum_api_format_htmlspecialchars($search_name);
         }
     }
     $PHORUM["DATA"]["HEADING"] = $PHORUM["DATA"]["LANG"]["SearchAllPosts"];


### PR DESCRIPTION
The new function phorum_api_format_htmlspecialchars replaces htmlspecialchars. Now we use ENT_QUOTES flag instead of ENT_COMPAT.