### PR TITLE
Redirect to index.php when there's no query string

### DIFF
--- a/addon.php
+++ b/addon.php
@@ -78,6 +78,14 @@ define('phorum_page', 'addon');
 
 require_once './common.php';
 
+// Search bots are trying to call this script without query string,
+// redirect to homepage.
+if (!$_GET && !$_POST && !$PHORUM['args']) {
+    header('HTTP/1.1 303 See Other');
+    header('Location: index.php');
+    exit;
+}
+
 // Bail out early if there are no modules enabled that implement
 // the addon hook.
 if (! isset($PHORUM["hooks"]["addon"])) trigger_error(


### PR DESCRIPTION
Fixing #1000 