### PR TITLE
Force password change option

### DIFF
--- a/common.php
+++ b/common.php
@@ -32,7 +32,7 @@ define( "PHORUM", "5.2.21" );
 define( "PHORUM_SCHEMA_VERSION", "2010101500" );
 
 // our database patch level in format of year-month-day-serial
-define( "PHORUM_SCHEMA_PATCHLEVEL", "2015082600" );
+define( "PHORUM_SCHEMA_PATCHLEVEL", "2016101000" );
 
 // Initialize the global $PHORUM variable, which holds all Phorum data.
 global $PHORUM;
@@ -996,6 +996,19 @@ if ( !defined( "PHORUM_ADMIN" ) ) {
             $PHORUM['DATA']['BREADCRUMBS'][$track]['URL'] = phorum_get_url(PHORUM_LIST_URL, $track);
         }
     }
+
+    // Check if user is forced to change his password and redirect to control center
+    if (    phorum_page !== 'control'
+         && phorum_page !== 'login'
+         && phorum_page !== 'ajax'
+         && phorum_page !== 'css'
+         && phorum_page !== 'javascript'
+         && isset($PHORUM['user']['force_password_change'])
+         && $PHORUM['user']['force_password_change'] ) {
+        phorum_redirect_by_url(phorum_get_url(PHORUM_CONTROLCENTER_ACTION_URL, 'panel=password'));
+        exit();
+    }
+
 }
 
 // ----------------------------------------------------------------------
@@ -1012,7 +1025,6 @@ else {
         require_once("./include/lang/$PHORUM[language].php");
     }
 }
-
 
 // ----------------------------------------------------------------------
 // Functions

--- a/control.php
+++ b/control.php
@@ -313,6 +313,7 @@ function phorum_controlcenter_user_save($panel)
     if ($panel == 'password') {
       $userdata['password'] = NULL;
       $userdata['password_temp'] = NULL;
+      $userdata['force_password_change'] = NULL;
     }
     // E-mail address related fields can only be updated from the email panel.
     if ($panel == 'email') {

--- a/include/api/user.php
+++ b/include/api/user.php
@@ -317,6 +317,7 @@ $GLOBALS['PHORUM']['API']['user_fields'] = array
   'moderation_email'        => 'bool',
   'moderator_data'          => 'array',
   'settings_data'           => 'array',
+  'force_password_change'   => 'bool',
 
    // Fields that are used for passing on information about user related,
    // data, which is not stored in a standard user table field.
@@ -1459,6 +1460,20 @@ function phorum_api_user_delete($user_id)
     foreach ($files as $file_id => $file) {
         phorum_api_file_delete($file_id);
     }
+}
+// }}}
+
+// {{{ Function: phorum_api_user_force_password_change()
+/**
+ * Set the "force password change" marker for all users except executing admin.
+ *
+ * @param integer $user_id
+ *     The administrators user_id.
+ */
+function phorum_api_user_force_password_change($user_id)
+{
+    settype($user_id, "int");
+    phorum_db_user_force_password_change($user_id);
 }
 // }}}
 

--- a/include/controlcenter/password.php
+++ b/include/controlcenter/password.php
@@ -17,11 +17,11 @@
 //   along with this program.                                                 //
 ////////////////////////////////////////////////////////////////////////////////
 
-if(!defined("PHORUM_CONTROL_CENTER")) return;
+if(!defined('PHORUM_CONTROL_CENTER')) return;
 
 if(count($_POST)) {
 
-    $old_password = trim($_POST["password_old"]);
+    $old_password = trim($_POST['password_old']);
     $new_password = trim($_POST['password_new']);
 
     // attempt to authenticate the user
@@ -30,17 +30,18 @@ if(count($_POST)) {
                                 $PHORUM['user']['username'],
                                 $old_password) ) {
 
-        $error = $PHORUM["DATA"]["LANG"]["ErrOriginalPassword"];
+        $error = $PHORUM['DATA']['LANG']['ErrOriginalPassword'];
 
     } elseif(empty($new_password) || empty($_POST['password_new2']) ||
             $_POST['password_new'] !== $_POST['password_new2']) {
 
-        $error = $PHORUM["DATA"]["LANG"]["ErrPassword"];
+        $error = $PHORUM['DATA']['LANG']['ErrPassword'];
 
     } else {
 
         // everything's good, save
         $_POST['password_temp'] = $_POST['password'] = $new_password;
+        $_POST['force_password_change'] = 0;
         list($error,$okmsg) = phorum_controlcenter_user_save($panel);
 
         // Redirect to the password page, to make sure that the
@@ -48,14 +49,20 @@ if(count($_POST)) {
         // session id and this session id changed along with the password.
         phorum_redirect_by_url(phorum_get_url(
             PHORUM_CONTROLCENTER_URL,
-            "panel=" . PHORUM_CC_PASSWORD,
-            "okmsg=" . urlencode($okmsg)
+            'panel=' . PHORUM_CC_PASSWORD,
+            'okmsg=' . urlencode($okmsg)
         ));
+    }
+} else {
+    // Check if user is forced to change his password and show message
+    if (    isset($PHORUM['user']['force_password_change'])
+         && $PHORUM['user']['force_password_change'] ) {
+        $error = $PHORUM['DATA']['LANG']['PasswordChange'];
     }
 }
 
-$PHORUM["DATA"]["HEADING"] = $PHORUM["DATA"]["LANG"]["ChangePassword"];
+$PHORUM['DATA']['HEADING'] = $PHORUM['DATA']['LANG']['ChangePassword'];
 $PHORUM['DATA']['PROFILE']['CHANGEPASSWORD'] = 1;
-$template = "cc_usersettings";
+$template = 'cc_usersettings';
 
 ?>

--- a/include/db/mysql.php
+++ b/include/db/mysql.php
@@ -4352,6 +4352,31 @@ function phorum_db_user_delete($user_id)
 }
 // }}}
 
+// {{{ Function: phorum_db_user_force_password_change()
+/**
+ * Set the "force password change" marker for all users except executing admin.
+ *
+ * @param integer $user_id
+ *     The administrators user_id.
+ */
+function phorum_db_user_force_password_change($user_id)
+{
+    settype($user_id, 'int');
+
+    if (!empty($user_id)) {
+        phorum_db_interact(
+            DB_RETURN_RES,
+            "UPDATE {$GLOBALS['PHORUM']['user_table']}
+             SET    force_password_change = 1
+             WHERE  force_password_change = 0
+             AND    user_id != $user_id",
+            NULL,
+            DB_MASTERQUERY
+        );
+    }
+}
+// }}}
+
 // {{{ Function: phorum_db_get_file_list()
 /**
  * Retrieve a list of files from the database.

--- a/include/db/upgrade/mysql-patches/2016101000.php
+++ b/include/db/upgrade/mysql-patches/2016101000.php
@@ -1,0 +1,6 @@
+<?php
+if (!defined('PHORUM_ADMIN')) return;
+
+$upgrade_queries[]="alter table {$PHORUM['user_table']} add column force_password_change tinyint(1) not null default '0';";
+
+?>

--- a/include/lang/english.php
+++ b/include/lang/english.php
@@ -341,6 +341,7 @@
         "Page"                  =>      "Page",
         "Pages"                 =>      "Pages",
         "Password"              =>      "Password",
+        "PasswordChange"        =>      "For security reasons, you are required to change your password.",
         "PeriodicLogin"         =>      "For your protection, you are required to confirm your login information when you have been away from the site.",
         "PermAdministrator"     =>      "You are an Administrator.",
         "PermAllowPost"         =>      "post-permission",


### PR DESCRIPTION
Start of renovation of our password system. First step: New
administrator option to force a password change for individual or all
users via the control center. After reload a page or after logging-in
the user lands directly on the (already existing) "change password"
dialog in the control center. A message in a red box says "For security
reasons, you are required to change your password.". The user can only
move inside the control center until he changed the password. Every
other link is redirected to the change password dialog.
