### PR TITLE
Fixed user registration

### DIFF
--- a/register.php
+++ b/register.php
@@ -34,16 +34,10 @@ if (isset($PHORUM["args"]["approve"])) {
     // Token is 16 hex chars; user_id is the integer suffix.
     $tmp_pass = substr($PHORUM["args"]["approve"], 0, 16);
     $user_id  = (int)substr($PHORUM["args"]["approve"], 16);
-    $user_id = phorum_api_user_search(
-        array("user_id", "password_temp"),
-        array($user_id,  $tmp_pass),
-        array("=",       "=")
-    );
+    $user = phorum_api_user_get($user_id);
 
     // Validation code correct.
-    if ($user_id) {
-
-        $user = phorum_api_user_get($user_id);
+    if ($user and phorum_db_user_check_login($user['username'], $tmp_pass, true)) {
 
         $moduser=array();
 


### PR DESCRIPTION
After upgrading 5 to 6.0.4, clicking on the link sent to users trying to register a new account resulted in the error message: "Sorry, there was an error verifying your account. Please make sure you used the entire URL included in the email you received. "

Since the user registration link is password_temp_cleartext + user_id but the password_temp stored in the database is now hashed, we need to convert user_id to username and then verify username, password_temp_cleartext against the encrypted password saved in password_temp

There may be a better way to do this, but this worked for me.